### PR TITLE
add support for all kinds of discrete data

### DIFF
--- a/R/Ostats_multivariate_plot.R
+++ b/R/Ostats_multivariate_plot.R
@@ -28,7 +28,7 @@
 #'   such as \code{method}. If none are provided, default values are used.
 #'
 #' @details Some of the code for generating contour lines is modified from
-#'   \code{\link{[hypervolume]{plot.HypervolumeList}}}.
+#'   \code{\link[hypervolume]{plot.HypervolumeList}}.
 #'
 #' @return Two-dimensional projections of species trait hypervolumes for each pair of traits,
 #'  plotted together for each community to show how they overlap each other.

--- a/R/pairwise_overlap.R
+++ b/R/pairwise_overlap.R
@@ -24,7 +24,7 @@
 #' @return A single numeric value that may range between 0 and 1.
 #'
 #' @noRd
-pairwise_overlap <- function(a, b, density_args = list(), hypervolume_set_args = list()) {
+pairwise_overlap <- function(a, b, discrete, density_args = list(), hypervolume_set_args = list()) {
 
   # Check structure of inputs a and b.
   # If they are unidimensional use density(), if >1 dimension use hypervolume()
@@ -34,14 +34,20 @@ pairwise_overlap <- function(a, b, density_args = list(), hypervolume_set_args =
     # calculate intersection density
     w <- pmin(a$y, b$y)
 
-    # integrate areas under curves
-    total <- sfsmisc::integrate.xy(a$x, a$y) + sfsmisc::integrate.xy(b$x, b$y)
-    intersection <- sfsmisc::integrate.xy(a$x, w)
+    if (!discrete) {
+      # If continuous, integrate the areas under curves
+      total <- sfsmisc::integrate.xy(a$x, a$y) + sfsmisc::integrate.xy(b$x, b$y)
+      intersection <- sfsmisc::integrate.xy(a$x, w)
+    } else {
+      # If discrete, take the overlaps at each discrete point
+      total <- sum(a$y + b$y)
+      intersection <- sum(w)
+    }
 
-    # compute overlap coefficient (Sorensen)
-    overlap_average <- 2 * intersection / total
+      # compute overlap coefficient (Sorensen)
+      overlap_average <- 2 * intersection / total
 
-    return(overlap_average)
+      return(overlap_average)
 
   } else {
     # Multivariate case

--- a/R/trait_density.R
+++ b/R/trait_density.R
@@ -9,7 +9,8 @@
 #' @param grid_limits 2 x n numeric matrix. Each column contains the minimum and
 #'   maximum value over which each trait's density function will be estimated.
 #' @param normal Passed from \code{\link{Ostats}}.
-#' @param data_type Passed from \code{\link{Ostats}}.
+#' @param discrete Passed from \code{\link{Ostats}}.
+#' @param circular Passed from \code{\link{Ostats}}.
 #' @param unique_values Vector of unique possible values for \code{x}.
 #'   Only used for discrete data types.
 #' @param density_args Passed from \code{\link{Ostats}}.
@@ -25,10 +26,10 @@
 #' In the multivariate case, returns an object of class \code{"hypervolume"}.
 #'
 #' @noRd
-trait_density <- function(x, grid_limits, normal, data_type, unique_values, density_args, circular_args) {
+trait_density <- function(x, grid_limits, normal, discrete, circular, unique_values, density_args, circular_args) {
   if (is.vector(x)) {
     # Univariate case
-    if (data_type %in% 'linear') {
+    if (!circular & !discrete) {
       # clean input
       x <- as.numeric(stats::na.omit(x))
 
@@ -58,7 +59,7 @@ trait_density <- function(x, grid_limits, normal, data_type, unique_values, dens
 
     }
 
-    if (data_type %in% 'circular') {
+    if (circular & !discrete) {
       # clean input
       x <- as.numeric(stats::na.omit(x))
 
@@ -91,7 +92,7 @@ trait_density <- function(x, grid_limits, normal, data_type, unique_values, dens
 
     }
 
-    if (data_type %in% 'circular_discrete') {
+    if (discrete) {
       x_weights <- calc_weight(x, normal, unique_values)
 
       d <- data.frame(x = x_weights[,'points'], y = x_weights[,'weights'])
@@ -127,10 +128,10 @@ trait_density <- function(x, grid_limits, normal, data_type, unique_values, dens
   }
 }
 
-#' Function to calculate hourly weights
+#' Function to calculate weights for discrete data.
 #' @noRd
 calc_weight <- function(x, normal, x_values) {
-  tab <- table(factor(x,  levels=as.character(x_values)),
+  tab <- table(factor(x, levels=as.character(x_values)),
                useNA="ifany")
 
   dimnames(tab) <- NULL

--- a/man/Ostats.Rd
+++ b/man/Ostats.Rd
@@ -8,7 +8,8 @@ Ostats(
   traits,
   plots,
   sp,
-  data_type = "linear",
+  discrete = FALSE,
+  circular = FALSE,
   output = "median",
   weight_type = "hmean",
   run_null_model = TRUE,
@@ -33,12 +34,19 @@ community each individual belongs to.}
 \item{sp}{a factor with length equal to \code{nrow(traits)} that indicates the taxon
 of each individual.}
 
-\item{data_type}{data type can be "linear", "circular", or "circular_discrete".
-Defaults to "linear". See details below.}
+\item{discrete}{whether trait data may take continuous or discrete values. Defaults to
+\code{FALSE} (all traits continuous). A single logical value or a logical
+vector with length equal to the number of columns in traits. See details below.}
 
-\item{output}{specifies whether median or mean is calculated.}
+\item{circular}{whether trait data are circular (e.g., hours or angles). Defaults to
+\code{FALSE} (all traits non-circular). A single logical value or a logical
+vector with length equal to the number of columns in traits. See details below.}
 
-\item{weight_type}{specifies weights to be used to calculate the median or mean.}
+\item{output}{specifies whether median or mean is calculated. Default \code{"median"}.}
+
+\item{weight_type}{specifies weights to be used to calculate the median or mean.
+Default \code{"hmean"} (harmonic mean), meaning each pair of species is weighted
+by the harmonic mean of abundances.}
 
 \item{run_null_model}{whether to run a null model (if \code{TRUE}) and evaluate the
 O-statistics against it, or simply return the raw O-statistics (if \code{FALSE}).
@@ -60,10 +68,11 @@ of null model output. A warning is issued, and a random seed is generated
 based on the local time, if the user does not supply a seed.}
 
 \item{unique_values}{Vector of all possible discrete values that \code{traits}
-can take. Only used if \code{data_type} is "circular_discrete".}
+can take. Only used if \code{discrete = TRUE} and \code{circular = TRUE}.}
 
 \item{circular_args}{optional list of additional arguments to pass to
-\code{\link[circular]{circular}}. Only used if the data type is "circular".
+\code{\link[circular]{circular}}. Only used if \code{circular = TRUE} and
+\code{discrete = FALSE}.
 Note that continuous circular data must be provided in radian units.}
 
 \item{density_args}{additional arguments to pass to \code{\link[stats]{density}}, such as
@@ -100,12 +109,16 @@ This function calculates overlap statistics and optionally evaluates them
   under all density functions to 1, the other making the area under all density
   functions proportional to the number of observations in that group.
 
-  If \code{data_type} is \code{"circular"}, the function \code{\link[circular]{circular}}
+  If \code{discrete = FALSE}, continuous kernel density functions are estimated for
+  each species at each community, if \code{TRUE}, discrete functions (histograms) are
+  estimated.
+
+  If \code{circular = TRUE} and \code{discrete = FALSE}, the function \code{\link[circular]{circular}}
   is used to convert each column of \code{traits} to an object of class circular.
   Unless additional arguments about input data type are specified, it is
   assumed that the circular input data are in radian units (0 to 2*pi).
 
-  If \code{data_type} is \code{"circular_discrete"} data will be interpreted as
+  If \code{circular = TRUE} and \code{discrete = TRUE}, data will be interpreted as
   discrete values on a circular scale. For example, data might be integer values
   representing hours and ranging from 0 to 23.
 

--- a/man/Ostats_multivariate_plot.Rd
+++ b/man/Ostats_multivariate_plot.Rd
@@ -74,7 +74,7 @@ This function plots the overlap of traits among
 }
 \details{
 Some of the code for generating contour lines is modified from
-  \code{\link{[hypervolume]{plot.HypervolumeList}}}.
+  \code{\link[hypervolume]{plot.HypervolumeList}}.
 }
 \seealso{
 \code{\link{Ostats_multivariate}} for generating multivariate O-statistics

--- a/man/community_overlap.Rd
+++ b/man/community_overlap.Rd
@@ -7,7 +7,8 @@
 community_overlap(
   traits,
   sp,
-  data_type = "linear",
+  discrete = FALSE,
+  circular = FALSE,
   normal = TRUE,
   output = "median",
   weight_type = "hmean",
@@ -25,8 +26,13 @@ matrix in the multivariate case where each column is a trait.}
 \item{sp}{a vector with length equal to length(traits) that indicates the
 taxon of each individual.}
 
-\item{data_type}{data type can be "linear", "circular", or "circular_discrete".
-Default to "linear".}
+\item{discrete}{whether trait data may take continuous or discrete values. Defaults to
+\code{FALSE} (all traits continuous). A single logical value or a logical
+vector with length equal to the number of columns in traits.}
+
+\item{circular}{whether trait data are circular (e.g., hours or angles). Defaults to
+\code{FALSE} (all traits non-circular). A single logical value or a logical
+vector with length equal to the number of columns in traits.}
 
 \item{normal}{if TRUE, the area under all density functions is normalized to 1,
 if FALSE, the area under all density functions is proportional to the number of
@@ -40,10 +46,11 @@ observations in that group.}
 within a community. This can be used to generate null models.}
 
 \item{unique_values}{Vector of all possible discrete values that \code{traits}
-can take. Only used if \code{data_type} is "circular_discrete".}
+can take. Only used if \code{discrete = TRUE} and \code{circular = TRUE}.}
 
-\item{circular_args}{list of additional arguments to be passed to
-\code{\link[circular]{circular}}. Only used if \code{data_type} is "circular".}
+\item{circular_args}{optional list of additional arguments to pass to
+\code{\link[circular]{circular}}. Only used if \code{circular = TRUE} and
+\code{discrete = FALSE}.}
 
 \item{density_args}{list of additional arguments to be passed to
 \code{\link[stats]{density}} if univariate, or

--- a/tests/testthat/test-Ostats.R
+++ b/tests/testthat/test-Ostats.R
@@ -69,16 +69,33 @@ test_that (
 result5 <- Ostats(traits = as.matrix(ant_data[, 'time', drop = FALSE]),
                   sp = factor(ant_data$species),
                   plots = factor(ant_data$chamber),
-                  data_type = "circular_discrete",
+                  discrete = TRUE,
+                  circular = TRUE,
                   unique_values = 0:23,
                   run_null_model = FALSE)$overlaps_norm
 
-expected5 <- matrix(c(0.6834, 0.6364), nrow = 2)
+expected5 <- matrix(c(0.6803, 0.6348), nrow = 2)
 
 test_that (
-  "the hourly circular data is handled correctly",
+  "discrete circular data is handled correctly",
   {
     expect_equivalent(result5, expected5, tolerance = 0.001)
   }
 )
 
+# Test 6: Non-circular discrete example. Use fake data with 0.75 overlap.
+result6 <- Ostats(traits = matrix(c(1,1,2,2,3,3,4,4,1,1,2,2,3,3,5,5), ncol = 1),
+                  sp = factor(rep(c('a','b'), c(8, 8))),
+                  plots = factor(rep('a', 16)),
+                  discrete = TRUE,
+                  circular = FALSE,
+                  run_null_model = FALSE)$overlaps_norm
+
+expected6 <- 0.75
+
+test_that (
+  "discrete non-circular data is handled correctly",
+  {
+    expect_equivalent(result6, expected6, tolerance = 0.001)
+  }
+)

--- a/vignettes/Ostats-introduction.Rmd
+++ b/vignettes/Ostats-introduction.Rmd
@@ -85,7 +85,9 @@ In the below example, all arguments are set to their default values.
 
 To explore the drivers of variation in body size overlap, `Ostats()` can implement a null model to test whether individual species’ body size distributions are more evenly spaced along the trait axis than expected by chance. This approach evaluates the z‐score of each observed community against the distribution of a user defined number of null communities. 
 
-* The argument `data_type` has a default value of `"linear"`, as the data processed are on a linear scale (i.e., body masses of individual small mammals). The alternative input for this argument is `"circular"` for data that are periodic (e.g., measured in radians or degrees). 
+* The argument `discrete` has a default value of `FALSE` for continuous variables. If `TRUE`, the data are treated as discrete.
+
+* The argument `circular` defaults to `TRUE`, meaning the data are on a linear scale (i.e., body masses of individual small mammals). The alternative  is `TRUE` for data that are periodic (e.g., measured in radians or degrees). 
 
 * The argument `output` specifies whether the median or mean of all pairwise overlap values between distributions of species will be returned. The default value for output is `"median"`. The choice between median and mean for the output is up to the investigator's discretion, and it is a good idea to see how much this choice influences the results of the analysis. For examples of analyses using the median and mean, respectively, see Read et al. 2018 and Mouillot et al. 2015.  
 
@@ -105,7 +107,6 @@ Running the function may take several minutes, depending on the size of the data
  Ostats_example <- Ostats(traits = as.matrix(dat[,'log_weight', drop = FALSE]),
                     sp = factor(dat$taxonID),
                     plots = factor(dat$siteID),
-                    data_type = "linear",
                     random_seed = 517)
 ```
 
@@ -146,7 +147,7 @@ These effect size values are used to compare the observed overlap statistics wit
 ## Overlap statistics for circular data against a local null model
 
 `Ostats()` can also be used to calculate overlap statistics of circular data, such as angular data (e.g., direction and orientation) or time. Two different kinds of circular calculations are available: continuous and discrete.
-To specify a circular analysis, set the argument `data_type = "circular"` if the data are circular and continuous, or set `data_type = "circular_discrete"` if the data are circular and discrete (i.e., collected every hour).
+To specify circular trait data, set the argument `discrete = FALSE` and `circular = TRUE` if the data are circular and continuous, or set `discrete = TRUE` and `circular = TRUE` if the data are circular and discrete (i.e., collected every hour).
 
 ### EXAMPLE: How to find the degree of overlap in time occurences for ant species present in a chamber, and compare across chambers of different conditions?
 
@@ -156,14 +157,15 @@ To illustrate the calculation of overlap statistics applied to discrete, circula
 head(ant_data)
 ```
 
-The arguments are similar to the linear data calculation. In the example below with `ant_data`, the input data are a record of ants in two chambers and their hour of occurrence. Because the time variable is discrete, we specify `"circular_discrete"` for the `data_type` argument. However, for continuous circular data, `data_type = "circular"` is used. We specify the argument `unique_values` to tabulate the density at all possible discrete values that the time of occurrence can take. In this case there are 24 possible values, `0:23`. Finally, `circular_args` can be used to pass additional arguments to the underlying function `circular::circular()` used to convert `traits` to objects of class `circular`.
+The arguments are similar to the linear data calculation. In the example below with `ant_data`, the input data are a record of ants in two chambers and their hour of occurrence. Because the time variable is discrete, we specify `discrete = TRUE` and `circular = TRUE`. We specify the argument `unique_values` to tabulate the density at all possible discrete values that the time of occurrence can take. In this case there are 24 possible values, `0:23`. Finally, for continuous circular data (not shown here), `circular_args` can be used to pass additional arguments to the underlying function `circular::circular()` used to convert `traits` to objects of class `circular`.
 
 ```{r echo = T, results='hide'}
 # Calculate overlap statistics for hourly data using the ant_data dataset
 circular_example <- Ostats(traits = as.matrix(ant_data[, 'time', drop = FALSE]),
                     sp = factor(ant_data$species),
                     plots = factor(ant_data$chamber),
-                    data_type = "circular_discrete",
+                    discrete = TRUE,
+                    circular = TRUE,
                     unique_values = 0:23,
                     random_seed = 519)
 ```


### PR DESCRIPTION
separate arguments for discrete and circular
fix a bug where discrete overlaps were not calculated correctly for circular either
Closes #43 