### PR TITLE
Add new bells and whistles to plotting code

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@ R/ignore/*
 ^docs$
 ^pkgdown$
 cran-comments.md
+tests/testthat/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /revdep
 inst/doc
 internal_docs/*.pdf
-
+tests/testthat/*.pdf

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -172,10 +172,16 @@ Ostats_plot<-function(plots,
     x_limits <- limits_x * range(traits[, i], na.rm = TRUE)
 
     if (!discrete) {
-      ggplot_dist <- ggplot2::ggplot(plot_dat) +
-        ggplot2::stat_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, geom='polygon', position = 'identity')
+      if (normalize) {
+        ggplot_dist <- ggplot2::ggplot(plot_dat) +
+          ggplot2::geom_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity')
+      } else {
+        ggplot_dist <- ggplot2::ggplot(plot_dat) +
+          ggplot2::geom_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], y = 'ggplot2::after_stat(count)', group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity')
+      }
     } else {
       # FIXME allow bin width argument
+      # FIXME allow no normalization of density
       ggplot_dist <- ggplot2::ggplot(plot_dat) +
         ggplot2::geom_histogram(ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity')
     }

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -41,12 +41,20 @@
 #' \code{circular}. Default is \code{FALSE}.
 #'
 #'@return Density plots of species trait distributions plotted together
-#'  for each community to show how they overlap each other.
+#'  for each community to show how they overlap each other. Each community
+#'  is plotted on a separate panel within a multipanel figure.
 #'  The overlap value obtained as output from \code{\link{Ostats}}
 #'  is labelled on each community graph, if provided by the user.
 #'
+#'  If trait values are discrete rather than continuous, histograms are
+#'  plotted instead of kernel density plots.
+#'
+#'  If trait values are circular, a circular kernel density estimate for
+#'  each species is plotted on a polar coordinate plot. If trait values are
+#'  both circular and discrete, a "sunburst" plot is returned.
+#'
 #'  The class of the returned object is \code{Ostats_plot_object}. Calling
-#'  \code{print} on this object will invoke a method to draw the plot using
+#'  \code{print} on this object will draw the plot using
 #'  \code{\link[grid]{grid.draw}}.
 #'
 #'  If more than one trait is provided, a list of objects of class
@@ -220,7 +228,11 @@ Ostats_plot<-function(plots,
     }
 
     } else {
-      # FIXME Include all the circular stuff here.
+      if (!discrete) {
+        # FIXME Here put the code for the circular continuous plot (polar density)
+      } else {
+        # FIXME Here put the code for the circular discrete plot (sunburst)
+      }
     }
 
     # Assign class attribute Ostats_plot_object so that the plot has a default print method.

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -41,7 +41,8 @@
 #' \code{circular}. Default is \code{FALSE}.
 #' @param circular_args optional list of additional arguments to pass to
 #'  \code{\link[circular]{circular}}. Only used if \code{circular = TRUE} and
-#'  \code{discrete = FALSE}.
+#'  \code{discrete = FALSE}. If no arguments are provided, default arguments to
+#'  \code{\link[circular]{circular}} are used.
 #'
 #'@return Density plots of species trait distributions plotted together
 #'  for each community to show how they overlap each other. Each community
@@ -133,9 +134,8 @@ Ostats_plot<-function(plots,
 
   # Calculate mean value by taxon.
   if (circular) {
-    # FIXME Currently hardcoded hours. Need to fix.
     mean_fn <- function(x) {
-      xcirc <- circular(x, units = 'hours')
+      xcirc <- do.call(circular::circular, c(list(x = x), circular_args))
       mean(xcirc, na.rm = TRUE)
     }
   } else {
@@ -221,9 +221,8 @@ Ostats_plot<-function(plots,
     } else {
       if (!discrete) {
         calc_circ_dens <- function(dat) {
-          # FIXME hours and bandwidth 24 are hardcoded in. This must be cahnged.
-          xcirc <- circular::circular(dat[,i], units = 'hours')
-          xcircdens <- circular::density.circular(xcirc, bw = 24)
+          xcirc <- do.call(circular::circular, c(list(x = dat[,i]), circular_args))
+          xcircdens <- circular::density.circular(xcirc, bw = diff(x_limits))
           cbind(sp = dat$sp[1], plots = dat$plots[1], with(xcircdens, data.frame(x=x, y=y)))
         }
 

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -132,7 +132,16 @@ Ostats_plot<-function(plots,
 
 
   # Calculate mean value by taxon.
-  taxon_mean <- stats::aggregate(traits, list(sp, plots), mean, na.rm = TRUE)
+  if (circular) {
+    # FIXME Currently hardcoded hours. Need to fix.
+    mean_fn <- function(x) {
+      xcirc <- circular(x, units = 'hours')
+      mean(xcirc, na.rm = TRUE)
+    }
+  } else {
+    mean_fn <- function(x) mean(x, na.rm = TRUE)
+  }
+  taxon_mean <- stats::aggregate(traits, list(sp, plots), mean_fn)
   names(taxon_mean) <- c('sp', 'plots', dimnames(traits)[[2]])
   taxon_mean <- taxon_mean[taxon_mean$plots %in% use_plots, ]
 
@@ -253,9 +262,14 @@ Ostats_plot<-function(plots,
 
         if (means) {
 
-          # FIXME Here include the code to produce ggplot_means on a circular coordinate grid
-
-          ggplot_means <- ...
+          ggplot_means <- ggplot2::ggplot(taxon_mean) +
+            ggplot2::geom_vline(ggplot2::aes_string(xintercept = dimnames(traits)[[2]][i], colour = 'sp', group='sp'), alpha = alpha, size=0.5, key_glyph = 'rect') +
+            ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
+            ggplot2::scale_colour_manual(values = colorvalues) +
+            ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
+            ggplot2::scale_y_continuous(expand = c(0,0)) +
+            ggplot2::coord_polar() +
+            ggplot2::theme(legend.position = if (!legend) 'none' else 'right')
 
           ggplot_dist <- gridExtra::arrangeGrob(ggplot_dist, ggplot_means, ncol = 2, widths = if (!legend) c(1, 1) else c(1, 1.3))
         } else {

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -16,7 +16,9 @@
 #' Defaults to a viridis palette if none provided.
 #'@param alpha defines the transparency level for the density polygons. Default is 0.5.
 #'@param adjust the bandwidth adjustment of the density polygons. Default is 2.
-#' See \code{\link[stats]{density}}.
+#' See \code{\link[stats]{density}}. Only used if \code{discrete = FALSE}.
+#'@param bin_width the width of each bin of the histograms. Default is 1.
+#' Only used if \code{discrete = TRUE}.
 #'@param limits_x Vector of length 2, with multiplicative factor to apply to the minimum
 #' and maximum values of each trait to expand the limits of the x axis.
 #' Default is 0.5 times the minimum and 1.5 times the maximum value of each trait.
@@ -80,6 +82,7 @@ Ostats_plot<-function(plots,
                       colorvalues = NULL,
                       alpha = 0.5,
                       adjust = 2,
+                      bin_width = 1,
                       limits_x = c(0.5, 1.5),
                       legend = FALSE,
                       name_x = 'trait value',
@@ -174,16 +177,19 @@ Ostats_plot<-function(plots,
     if (!discrete) {
       if (normalize) {
         ggplot_dist <- ggplot2::ggplot(plot_dat) +
-          ggplot2::geom_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity')
+          ggplot2::geom_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity', color = NA)
       } else {
         ggplot_dist <- ggplot2::ggplot(plot_dat) +
-          ggplot2::geom_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], y = 'ggplot2::after_stat(count)', group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity')
+          ggplot2::geom_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], y = 'ggplot2::after_stat(count)', group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity', color = NA)
       }
     } else {
-      # FIXME allow bin width argument
-      # FIXME allow no normalization of density
-      ggplot_dist <- ggplot2::ggplot(plot_dat) +
-        ggplot2::geom_histogram(ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, position = 'identity')
+      if (normalize) {
+        ggplot_dist <- ggplot2::ggplot(plot_dat) +
+          ggplot2::geom_histogram(ggplot2::aes_string(x = dimnames(traits)[[2]][i], y = 'ggplot2::after_stat(density * width)', fill = 'sp'), alpha = alpha, position = 'identity', binwidth = bin_width)
+      } else {
+        ggplot_dist <- ggplot2::ggplot(plot_dat) +
+          ggplot2::geom_histogram(ggplot2::aes_string(x = dimnames(traits)[[2]][i], fill = 'sp'), alpha = alpha, position = 'identity', binwidth = bin_width)
+      }
     }
 
     ggplot_dist <- ggplot_dist +

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -21,7 +21,9 @@
 #' Only used if \code{discrete = TRUE}.
 #'@param limits_x Vector of length 2, with multiplicative factor to apply to the minimum
 #' and maximum values of each trait to expand the limits of the x axis.
-#' Default is 0.5 times the minimum and 1.5 times the maximum value of each trait.
+#' Default is \code{c(0.5, 1.5)}, or 0.5 times the minimum and 1.5 times the maximum
+#' value of each trait, for continuous traits. For discrete traits the default is
+#' \code{c(1, 1)} or no expansion of limits.
 #'@param legend Whether to include a legend. Defaults to \code{FALSE}.
 #'@param scale If you want the scale of x, y or both x and y axis to be independent,
 #' set the argument to "free_x", "free_y" or "free" respectively.
@@ -95,7 +97,7 @@ Ostats_plot<-function(plots,
                       alpha = 0.5,
                       adjust = 2,
                       bin_width = 1,
-                      limits_x = c(0.5, 1.5), # FIXME Default for discrete should be 1,1
+                      limits_x = NULL,
                       legend = FALSE,
                       name_x = 'trait value',
                       name_y = 'probability density',
@@ -106,6 +108,9 @@ Ostats_plot<-function(plots,
                       circular_args = list()) {
 
   if (means & discrete) stop('Plotting trait means is not supported for discrete traits.')
+
+  if (missing(limits_x) & !discrete) limits_x <- c(0.5, 1.5)
+  if (missing(limits_x) & discrete) limits_x <- c(1, 1)
 
   # Unless a subset of sites is provided, use all sites in dataset.
   if (is.null(use_plots)) {
@@ -232,7 +237,7 @@ Ostats_plot<-function(plots,
         circ_dens_data <- by(plot_dat, list(sp, plots), calc_circ_dens)
         plot_binned <- do.call(rbind, circ_dens_data)
 
-        ggplot_dist <- ggplot2::ggplot(plot_binned, aes(x=x, y=y, fill=sp)) +
+        ggplot_dist <- ggplot2::ggplot(plot_binned, ggplot2::aes(x=x, y=y, fill=sp)) +
           ggplot2::geom_polygon(alpha = alpha) +
           ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
           ggplot2::scale_fill_manual(values = colorvalues) +
@@ -279,7 +284,7 @@ Ostats_plot<-function(plots,
         plot_binned$Var1 <- plot_binned$Var1 + jitter_seq[plot_binned$sp]
 
         ggplot_dist <- ggplot2::ggplot(plot_binned) +
-          ggplot2::geom_segment(aes(x = Var1, xend = Var1, y = 0, yend = Freq, group = sp, color = sp), alpha = 1/2, size = 1.2) +
+          ggplot2::geom_segment(ggplot2::aes(x = Var1, xend = Var1, y = 0, yend = Freq, group = sp, color = sp), alpha = 1/2, size = 1.2) +
           ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
           ggplot2::scale_color_manual(values = colorvalues) +
           ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +

--- a/R/Ostats_plot.R
+++ b/R/Ostats_plot.R
@@ -95,7 +95,7 @@ Ostats_plot<-function(plots,
                       alpha = 0.5,
                       adjust = 2,
                       bin_width = 1,
-                      limits_x = c(0.5, 1.5),
+                      limits_x = c(0.5, 1.5), # FIXME Default for discrete should be 1,1
                       legend = FALSE,
                       name_x = 'trait value',
                       name_y = 'probability density',
@@ -169,9 +169,9 @@ Ostats_plot<-function(plots,
                                    lab = paste('Overlap =', signif(ostat_norm[,i], 2)))
     }
 
-    if (!circular) {
+    x_limits <- limits_x * range(traits[, i], na.rm = TRUE)
 
-      x_limits <- limits_x * range(traits[, i], na.rm = TRUE)
+    if (!circular) {
 
       if (!discrete) {
         if (normalize) {
@@ -220,6 +220,8 @@ Ostats_plot<-function(plots,
 
     } else {
       if (!discrete) {
+        # FIXME currently we do not get different results for each trait.
+        # FIXME normalization is ignored currently. Must be added.
         calc_circ_dens <- function(dat) {
           xcirc <- do.call(circular::circular, c(list(x = dat[,i]), circular_args))
           xcircdens <- circular::density.circular(xcirc, bw = diff(x_limits))
@@ -239,6 +241,7 @@ Ostats_plot<-function(plots,
 
         if (means) {
 
+          # FIXME currently this returns an error.
           ggplot_means <- ggplot2::ggplot(taxon_mean) +
             ggplot2::geom_vline(ggplot2::aes_string(xintercept = dimnames(traits)[[2]][i], colour = 'sp', group='sp'), alpha = alpha, size=0.5, key_glyph = 'rect') +
             ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +

--- a/R/ignore/circle_fig_multitrait_testing.R
+++ b/R/ignore/circle_fig_multitrait_testing.R
@@ -18,7 +18,7 @@ color_values <- c("#E41A1C", "#377EB8", "#4DAF4A")
 # Not circular
 Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, means = TRUE) # OK
 Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, means = TRUE) # OK
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE) # OK
+suppressWarnings(Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE)) # OK
 Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE) # OK
 
 # Circular

--- a/R/ignore/circle_fig_multitrait_testing.R
+++ b/R/ignore/circle_fig_multitrait_testing.R
@@ -1,7 +1,6 @@
 # Testing: create a figure with ant data
 
 library(Ostats)
-library(ggplot2)
 
 data(ant_data)
 
@@ -14,19 +13,18 @@ ant_data$time3 <- ant_data$time %% 6
 sp=ant_data$species
 plots=ant_data$chamber
 traits=ant_data[, c('time', 'time2', 'time3')]
-color_values <- RColorBrewer::brewer.pal(3, 'Set1')
+color_values <- c("#E41A1C", "#377EB8", "#4DAF4A")
 
 # Not circular
 Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, means = TRUE) # OK
 Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, means = TRUE) # OK
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, limits_x = c(1, 1)) # OK, fix lims default
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, limits_x = c(1, 1)) # OK, fix lims default
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE) # OK
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE) # OK
 
 # Circular
 pc1 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, circular = TRUE)
 pc2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, circular = TRUE)
-pc3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, circular = TRUE, limits_x = c(1, 1))
-pc4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, circular = TRUE, limits_x = c(1, 1))
-
+pc3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, circular = TRUE)
+pc4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, circular = TRUE)
 pc5 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, circular = TRUE, means = TRUE)
 pc6 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)

--- a/R/ignore/circle_fig_multitrait_testing.R
+++ b/R/ignore/circle_fig_multitrait_testing.R
@@ -9,127 +9,21 @@ data(ant_data)
 ant_data$time2 <- ant_data$time %% 12
 ant_data$time3 <- ant_data$time %% 6
 
-# Discrete circular data
+## Test all combinations
 
 sp=ant_data$species
 plots=ant_data$chamber
-plot_dat=ant_data
-traits=ant_data[, "time", drop=F]
-adjust=2
-scale="fixed"
-n_col=2
-x_limits=c(0,23)
-name_x="Trait"
-name_y="Number"
-names(plot_dat)[2] <- "plots"
-i=1
-alpha <- 0.5
-colorvalues <- sample(viridis::viridis(length(unique(sp)), alpha = alpha))
+traits=ant_data[, c('time', 'time2', 'time3')]
+color_values <- RColorBrewer::brewer.pal(3, 'Set1')
 
-names(colorvalues) <- unique(sp)
+# Not circular
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, means = TRUE)
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, means = TRUE)
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, limits_x = c(1, 1))
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, limits_x = c(1, 1))
 
-ggplot2::theme_set(
-  ggplot2::theme_bw() + ggplot2::theme(panel.grid = ggplot2::element_blank(),
-                                       axis.text = ggplot2::element_text(size = 12),
-                                       axis.title = ggplot2::element_text(size = 12),
-                                       axis.text.y = ggplot2::element_blank(),
-                                       axis.ticks.y = ggplot2::element_blank(),
-                                       strip.background = ggplot2::element_blank()))
-
-
-# Discrete plot.
-# Issue: If area is used, it keeps getting wider as you get further from the origin so it gives a biased depiction of the overlap.
-(
-  ggplot_dist <- ggplot2::ggplot(plot_dat) +
-    ggplot2::geom_histogram(aes(x = time, group = sp, fill = sp), alpha = 1/3, position = 'identity', binwidth = 1) +
-    #ggplot2::stat_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, geom='polygon', position = 'identity') +
-    ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
-    ggplot2::scale_fill_manual(values = colorvalues) +
-    ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-    #ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
-    ggplot2::coord_polar()
-  #ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
-)
-
-# Solution: manually bin the discrete data first, grouped by sp and plots,
-
-## calculate manual jitter factor
-jitter_width <- 10/diff(x_limits)
-jitter_seq <- seq(from = -jitter_width, to = jitter_width, length.out = length(unique(sp)))
-
-# If desired to normalize:
-segment_heights <- by(plot_dat, list(sp, plots), function(x) cbind(sp = x$sp[1], plots = x$plots[1], as.data.frame.table(table(x$time)/sum(x$time), stringsAsFactors = FALSE)))
-
-# If not desired to normalize:
-segment_heights <- by(plot_dat, list(sp, plots), function(x) cbind(sp = x$sp[1], plots = x$plots[1], as.data.frame.table(table(x$time), stringsAsFactors = FALSE)))
-
-plot_binned <- do.call(rbind, segment_heights)
-plot_binned$Var1 <- as.numeric(plot_binned$Var1)
-
-# Jitter manually
-plot_binned$Var1 <- plot_binned$Var1 + jitter_seq[plot_binned$sp]
-
-# This does a great job of resolving the issue except for the overplotting
-# But if position_dodge is used it will cause them to curve
-# Use manual jittering to deal with this
-
-(
-  ggplot_dist <- ggplot2::ggplot(plot_binned) +
-    ggplot2::geom_segment(aes(x = Var1, xend = Var1, y = 0, yend = Freq, group = sp, color = sp), alpha = 1/2, size = 1.2) +
-   # ggplot2::geom_segment(aes(x = Var1, xend = Var1, y = 0, yend = Freq, group = sp, color = sp), alpha = 1/2, position = "identity", size = 1.5) +
-    #ggplot2::stat_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, geom='polygon', position = 'identity') +
-    ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
-    ggplot2::scale_color_manual(values = colorvalues) +
-    ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-    #ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
-    ggplot2::coord_polar()
-  #ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
-)
-
-
-### Use circular::density() to get kernel density estimate for circular data and plot.\
-## test for one combination
-
-library(circular)
-x <- plot_dat$time[plot_dat$species == "Camponotus castaneus" & plot_dat$plots == 1]
-xcirc <- circular(x, units = 'hours')
-
-xcircdens <- density(xcirc, bw = 24)
-
-xcircdens_data <- with(xcircdens, data.frame(x=x, y=y))
-
-## use by() to get for all plots and species
-calc_circ_dens <- function(dat) {
-  xcirc <- circular(dat$time, units = 'hours')
-  xcircdens <- density(xcirc, bw = 24)
-  cbind(sp = dat$sp[1], plots = dat$plots[1], with(xcircdens, data.frame(x=x, y=y)))
-}
-
-circ_dens_data <- by(plot_dat, list(sp, plots), calc_circ_dens)
-plot_binned <- do.call(rbind, circ_dens_data)
-
-(
-ggplot_dist <- ggplot2::ggplot(plot_binned, aes(x=x, y=y, fill=sp)) +
-  ggplot2::geom_polygon(alpha = 1/3) +
-    ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
-  ggplot2::scale_fill_manual(values = colorvalues) +
-  ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-  ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
-  ggplot2::coord_polar()
-)
-
-
-### Discrete non-circular data (example)
-bin_width = 1
-legend = TRUE
-means = FALSE
-
-ggplot_dist <- ggplot2::ggplot(plot_dat) +
-  ggplot2::geom_histogram(ggplot2::aes_string(x = dimnames(traits)[[2]][i], y = 'ggplot2::after_stat(density * width)', fill = 'sp'), alpha = alpha, position = 'identity', binwidth = bin_width)
-
-ggplot_dist <- ggplot_dist +
-  ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
-  ggplot2::scale_fill_manual(values = colorvalues) +
-  ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-  ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
-  ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
+# Circular
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, circular = TRUE)
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, circular = TRUE)
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, circular = TRUE, limits_x = c(1, 1))
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, circular = TRUE, limits_x = c(1, 1))

--- a/R/ignore/circle_fig_multitrait_testing.R
+++ b/R/ignore/circle_fig_multitrait_testing.R
@@ -17,13 +17,16 @@ traits=ant_data[, c('time', 'time2', 'time3')]
 color_values <- RColorBrewer::brewer.pal(3, 'Set1')
 
 # Not circular
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, means = TRUE)
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, means = TRUE)
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, limits_x = c(1, 1))
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, limits_x = c(1, 1))
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, means = TRUE) # OK
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, means = TRUE) # OK
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, limits_x = c(1, 1)) # OK, fix lims default
+Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, limits_x = c(1, 1)) # OK, fix lims default
 
 # Circular
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, circular = TRUE)
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, circular = TRUE)
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, circular = TRUE, limits_x = c(1, 1))
-Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, circular = TRUE, limits_x = c(1, 1))
+pc1 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, circular = TRUE)
+pc2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, circular = TRUE)
+pc3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = TRUE, circular = TRUE, limits_x = c(1, 1))
+pc4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = TRUE, normalize = FALSE, circular = TRUE, limits_x = c(1, 1))
+
+pc5 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = TRUE, circular = TRUE, means = TRUE)
+pc6 <- Ostats_plot(plots = plots, sp = sp, traits = traits, colorvalues = color_values, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)

--- a/R/ignore/circle_fig_multitrait_testing.R
+++ b/R/ignore/circle_fig_multitrait_testing.R
@@ -87,7 +87,7 @@ plot_binned$Var1 <- plot_binned$Var1 + jitter_seq[plot_binned$sp]
 )
 
 
-### Use circular::density() to get kernel density estimate for continuous circular data and plot.
+### Use circular::density() to get kernel density estimate for circular data and plot.\
 ## test for one combination
 
 library(circular)
@@ -118,26 +118,6 @@ ggplot_dist <- ggplot2::ggplot(plot_binned, aes(x=x, y=y, fill=sp)) +
   ggplot2::coord_polar()
 )
 
-### Means plotted as radii for continuous circular data ggplot_means.
-calc_circ_mean <- function(x) {
-  xcirc <- circular(x, units = 'hours')
-  mean(xcirc, na.rm = TRUE)
-}
-
-taxon_mean <- stats::aggregate(traits, list(sp, plots), calc_circ_mean)
-names(taxon_mean) <- c('sp', 'plots', dimnames(traits)[[2]])
-taxon_mean <- taxon_mean[taxon_mean$plots %in% use_plots, ]
-
-(
-ggplot_means <- ggplot2::ggplot(taxon_mean) +
-  ggplot2::geom_vline(ggplot2::aes_string(xintercept = dimnames(traits)[[2]][i], colour = 'sp', group='sp'), alpha = alpha, size=0.5, key_glyph = 'rect') +
-  ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
-  ggplot2::scale_colour_manual(values = colorvalues) +
-  ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-  ggplot2::scale_y_continuous(expand = c(0,0)) +
-  ggplot2::coord_polar() +
-  ggplot2::theme(legend.position = if (!legend) 'none' else 'right')
-)
 
 ### Discrete non-circular data (example)
 bin_width = 1

--- a/R/ignore/circle_fig_testing.R
+++ b/R/ignore/circle_fig_testing.R
@@ -76,14 +76,12 @@ plot_binned$Var1 <- plot_binned$Var1 + jitter_seq[plot_binned$sp]
 (
   ggplot_dist <- ggplot2::ggplot(plot_binned) +
     ggplot2::geom_segment(aes(x = Var1, xend = Var1, y = 0, yend = Freq, group = sp, color = sp), alpha = 1/2, size = 1.2) +
-   # ggplot2::geom_segment(aes(x = Var1, xend = Var1, y = 0, yend = Freq, group = sp, color = sp), alpha = 1/2, position = "identity", size = 1.5) +
-    #ggplot2::stat_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, geom='polygon', position = 'identity') +
     ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
     ggplot2::scale_color_manual(values = colorvalues) +
     ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-    #ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
-    ggplot2::coord_polar()
-  #ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
+    ggplot2::scale_y_continuous(name = name_y) +
+    ggplot2::coord_polar() +
+    ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
 )
 
 

--- a/R/ignore/circle_fig_testing.R
+++ b/R/ignore/circle_fig_testing.R
@@ -109,12 +109,11 @@ circ_dens_data <- by(plot_dat, list(sp, plots), calc_circ_dens)
 plot_binned <- do.call(rbind, circ_dens_data)
 
 (
-xcircdens_gg <- ggplot2::ggplot(plot_binned, aes(x=x, y=y, fill=sp)) +
+ggplot_dist <- ggplot2::ggplot(plot_binned, aes(x=x, y=y, fill=sp)) +
   ggplot2::geom_polygon(alpha = 1/3) +
     ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
   ggplot2::scale_fill_manual(values = colorvalues) +
   ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
   ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
   ggplot2::coord_polar()
-#ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
 )

--- a/R/ignore/circle_fig_testing.R
+++ b/R/ignore/circle_fig_testing.R
@@ -99,7 +99,7 @@ xcircdens_data <- with(xcircdens, data.frame(x=x, y=y))
 ## use by() to get for all plots and species
 calc_circ_dens <- function(dat) {
   xcirc <- circular(dat$time, units = 'hours')
-  xcircdens <- density(xcirc, bw = 24)
+  xcircdens <- density(xcirc, bw = max(x_limits))
   cbind(sp = dat$sp[1], plots = dat$plots[1], with(xcircdens, data.frame(x=x, y=y)))
 }
 

--- a/R/ignore/circle_fig_testing.R
+++ b/R/ignore/circle_fig_testing.R
@@ -37,17 +37,6 @@ ggplot2::theme_set(
                                        strip.background = ggplot2::element_blank()))
 
 
-(
-ggplot_dist <- ggplot2::ggplot(plot_dat) +
-  ggplot2::stat_density(adjust = adjust, ggplot2::aes_string(x = dimnames(traits)[[2]][i], group = 'sp', fill = 'sp'), alpha = alpha, geom='polygon', position = 'identity') +
-  ggplot2::facet_wrap(~ plots, ncol = n_col, scales = scale) +
-  ggplot2::scale_fill_manual(values = colorvalues) +
-  ggplot2::scale_x_continuous(name = name_x, limits = x_limits) +
-  #ggplot2::scale_y_continuous(name = name_y, expand = c(0,0)) +
-  ggplot2::coord_polar()
-  #ggplot2::theme(legend.position = if (!legend | means) 'none' else 'right')
-)
-
 # Discrete plot.
 # Issue: If area is used, it keeps getting wider as you get further from the origin so it gives a biased depiction of the overlap.
 (

--- a/tests/testthat/test-Ostats.R
+++ b/tests/testthat/test-Ostats.R
@@ -10,92 +10,84 @@ dat <- dat[!is.na(dat$weight), ]
 dat$log_weight <- log10(dat$weight)
 
 # Test 1: one community with multiple species
-result1 <- Ostats(traits = as.matrix(dat[, 'log_weight', drop = FALSE]), plots = factor(dat$siteID), sp = factor(dat$taxonID), run_null_model = FALSE)$overlaps_norm
-expected1 <- matrix(c(0.8946, 0.0183), nrow = 2)
-
 test_that (
   "Ostats returns expected output",
   {
+    result1 <- Ostats(traits = as.matrix(dat[, 'log_weight', drop = FALSE]), plots = factor(dat$siteID), sp = factor(dat$taxonID), run_null_model = FALSE)$overlaps_norm
+    expected1 <- matrix(c(0.8946, 0.0183), nrow = 2)
     expect_equivalent(result1, expected1, tolerance = 0.001)
   }
 )
 
 # Test 2: multiple communities, one of which has only one species
-dat2 <- dat[dat$siteID %in% 'HARV' | dat$taxonID %in% 'CHPE', ]
-result2 <- Ostats(traits = as.matrix(dat2[, 'log_weight', drop = FALSE]), plots = factor(dat2$siteID), sp = factor(dat2$taxonID), run_null_model = FALSE)$overlaps_norm
-expected2 <- matrix(c(0.8946, NA), nrow = 2)
-
 test_that (
   "Ostats deals with communities with only one species",
   {
+    dat2 <- dat[dat$siteID %in% 'HARV' | dat$taxonID %in% 'CHPE', ]
+    result2 <- Ostats(traits = as.matrix(dat2[, 'log_weight', drop = FALSE]), plots = factor(dat2$siteID), sp = factor(dat2$taxonID), run_null_model = FALSE)$overlaps_norm
+    expected2 <- matrix(c(0.8946, NA), nrow = 2)
     expect_equivalent(result2, expected2, tolerance = 0.001)
   }
 )
 
 # Test 3: species with insufficient data for density estimate
 # Edge case where every species in the community has only one individual. Should return NA.
-
-dat3 <- do.call(rbind, lapply(split(dat, interaction(dat$siteID, dat$taxonID), drop = TRUE),
-                              function(x) x[1,]))
-result3 <- Ostats(traits = as.matrix(dat3[, 'log_weight', drop = FALSE]), plots = factor(dat3$siteID), sp = factor(dat3$taxonID), run_null_model = FALSE)$overlaps_norm
-expected3 <- matrix(c(NA, NA), nrow = 2)
-
-
 test_that (
   "Ostats deals with species with insufficient data",
   {
+    dat3 <- do.call(rbind, lapply(split(dat, interaction(dat$siteID, dat$taxonID), drop = TRUE),
+                                  function(x) x[1,]))
+    result3 <- Ostats(traits = as.matrix(dat3[, 'log_weight', drop = FALSE]), plots = factor(dat3$siteID), sp = factor(dat3$taxonID), run_null_model = FALSE)$overlaps_norm
+    expected3 <- matrix(c(NA, NA), nrow = 2)
     expect_equivalent(result3, expected3, tolerance = 0.001)
   }
 )
 
 ### Additional tests from vignette
 # Test 4: Additional arguments to density, vignette line 111
-result4 <- Ostats(traits = as.matrix(dat[,'log_weight', drop = FALSE]),
-                  sp = factor(dat$taxonID),
-                  plots = factor(dat$siteID),
-                  run_null_model = FALSE,
-                  density_args=list(bw = 'nrd0', adjust = 2, n=200))$overlaps_norm
-expected4 <- matrix(c(0.895,0.0188), nrow = 2)
-
 test_that (
   "Ostats handles the different density arguments correctly",
   {
+    result4 <- Ostats(traits = as.matrix(dat[,'log_weight', drop = FALSE]),
+                      sp = factor(dat$taxonID),
+                      plots = factor(dat$siteID),
+                      run_null_model = FALSE,
+                      density_args=list(bw = 'nrd0', adjust = 2, n=200))$overlaps_norm
+    expected4 <- matrix(c(0.895,0.0188), nrow = 2)
     expect_equivalent(result4, expected4, tolerance = 0.001)
   }
 )
 
 # Test 5: Circular data example from vignette line 162
 # Is the hourly circular data handled correctly?
-result5 <- Ostats(traits = as.matrix(ant_data[, 'time', drop = FALSE]),
-                  sp = factor(ant_data$species),
-                  plots = factor(ant_data$chamber),
-                  discrete = TRUE,
-                  circular = TRUE,
-                  unique_values = 0:23,
-                  run_null_model = FALSE)$overlaps_norm
-
-expected5 <- matrix(c(0.6803, 0.6348), nrow = 2)
-
 test_that (
   "discrete circular data is handled correctly",
   {
+    result5 <- Ostats(traits = as.matrix(ant_data[, 'time', drop = FALSE]),
+                      sp = factor(ant_data$species),
+                      plots = factor(ant_data$chamber),
+                      discrete = TRUE,
+                      circular = TRUE,
+                      unique_values = 0:23,
+                      run_null_model = FALSE)$overlaps_norm
+
+    expected5 <- matrix(c(0.6803, 0.6348), nrow = 2)
     expect_equivalent(result5, expected5, tolerance = 0.001)
   }
 )
 
 # Test 6: Non-circular discrete example. Use fake data with 0.75 overlap.
-result6 <- Ostats(traits = matrix(c(1,1,2,2,3,3,4,4,1,1,2,2,3,3,5,5), ncol = 1),
-                  sp = factor(rep(c('a','b'), c(8, 8))),
-                  plots = factor(rep('a', 16)),
-                  discrete = TRUE,
-                  circular = FALSE,
-                  run_null_model = FALSE)$overlaps_norm
-
-expected6 <- 0.75
-
 test_that (
   "discrete non-circular data is handled correctly",
   {
+    result6 <- Ostats(traits = matrix(c(1,1,2,2,3,3,4,4,1,1,2,2,3,3,5,5), ncol = 1),
+                      sp = factor(rep(c('a','b'), c(8, 8))),
+                      plots = factor(rep('a', 16)),
+                      discrete = TRUE,
+                      circular = FALSE,
+                      run_null_model = FALSE)$overlaps_norm
+
+    expected6 <- 0.75
     expect_equivalent(result6, expected6, tolerance = 0.001)
   }
 )

--- a/tests/testthat/test-Ostats_multivariate.R
+++ b/tests/testthat/test-Ostats_multivariate.R
@@ -5,38 +5,35 @@ context("Ostats_multivariate")
 iris_traits <- as.matrix(iris[,1:4])
 
 # Test 1: Does iris return appropriate output?
-result1 <- Ostats_multivariate(traits = iris_traits, plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE, hypervolume_args = list(method = 'box'), hypervolume_set_args = list(num.points.max = 1000))
-result1 <- as.numeric(result1$overlaps_norm)
-expected1 <- c(0.755, 0.783)
-
 test_that (
   "Ostats_multivariate returns expected output",
   {
+    result1 <- Ostats_multivariate(traits = iris_traits, plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE, hypervolume_args = list(method = 'box'), hypervolume_set_args = list(num.points.max = 1000))
+    result1 <- as.numeric(result1$overlaps_norm)
+    expected1 <- c(0.755, 0.783)
     expect_equal(result1, expected1, tolerance = 0.01)
   }
 )
 
 # Test 2: run multivariate data on single trait
-result2 <- Ostats_multivariate(traits = iris_traits[,1,drop=FALSE], plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE)
-expected2 <- Ostats(traits = iris_traits[,1,drop=FALSE], plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE)
-
 # expect_equivalent ignores names.
 test_that (
   "Ostats_multivariate returns the same output as Ostats if one trait is selected",
   {
+    result2 <- Ostats_multivariate(traits = iris_traits[,1,drop=FALSE], plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE)
+    expected2 <- Ostats(traits = iris_traits[,1,drop=FALSE], plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE)
     expect_equivalent(result2$overlaps_norm, expected2$overlaps_norm, tolerance = 0.01)
   }
 )
 
 # Test 3: Are the alternate arguments to hypervolume and hypervolume_set passed through correctly?
-result3 <- Ostats_multivariate(traits = iris_traits, plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE,
-                               hypervolume_args = list(method = 'box'), hypervolume_set_args = list(distance.factor = 2, num.points.max = 1000))
-result3 <- as.numeric(result3$overlaps_norm)
-expected3 <- c(0.93, 0.95)
-
 test_that (
   "Ostats_multivariate correctly handles arguments to hypervolume functions",
   {
+    result3 <- Ostats_multivariate(traits = iris_traits, plots = factor(rep(c('a','b'),times=75)), sp = iris$Species, random_seed = 111, run_null_model = FALSE,
+                                   hypervolume_args = list(method = 'box'), hypervolume_set_args = list(distance.factor = 2, num.points.max = 1000))
+    result3 <- as.numeric(result3$overlaps_norm)
+    expected3 <- c(0.93, 0.95)
     expect_equal(result3, expected3, tolerance = 0.01)
   }
 )

--- a/tests/testthat/test-Ostats_plot.R
+++ b/tests/testthat/test-Ostats_plot.R
@@ -1,6 +1,86 @@
 library(Ostats)
 context("Ostats_plot")
 
-# Unit tests for Ostats_plot() to be put here.
-# Tests should verify that an object of class Ostats_plot_object is created successfully
+# Tests verify that objects of the correct class are created
 # for continuous data, discrete data, and circular data.
+# If a single trait is plotted, test inherits(p, "Ostats_plot_object")
+# If multiple traits are plotted, test length(p) == number of traits
+# and all(sapply(p, inherits, "Ostats_plot_object"))
+
+# Set up data for test, making multiple trait columns from the ant data.
+data(ant_data)
+
+ant_data$time2 <- ant_data$time %% 12
+ant_data$time3 <- ant_data$time %% 6
+
+sp <- ant_data$species
+plots <- ant_data$chamber
+traits <- ant_data[, c('time', 'time2', 'time3')]
+
+# Multiple traits:
+plist1 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, means = TRUE)
+plist2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE)
+plist3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)
+plist4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE, circular = TRUE)
+
+# Tests 1-4: single trait plots
+test_that(
+  "Single continuous trait plot with means panels returns valid output",
+  {
+    p1 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = FALSE, normalize = FALSE, means = TRUE)
+    expect_true(inherits(p1, "Ostats_plot_object"))
+  }
+)
+
+test_that(
+  "Single discrete trait plot returns valid output",
+  {
+    p2 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = TRUE, normalize = FALSE)
+    expect_true(inherits(p2, "Ostats_plot_object"))
+  }
+)
+
+test_that(
+  "Single continuous circular trait plot with means panels returns valid output",
+  {
+    p3 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)
+    expect_true(inherits(p3, "Ostats_plot_object"))
+  }
+)
+
+test_that(
+  "Single discrete circular trait plot returns valid output",
+  {
+    p4 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = TRUE, normalize = FALSE, circular = TRUE)
+    expect_true(inherits(p4, "Ostats_plot_object"))
+  }
+)
+
+# Tests 5-8: multiple trait plots
+test_that(
+  "Multiple continuous trait plot with means panels returns valid output",
+  {
+    expect_true(length(plist1) == 3L & all(sapply(plist1, inherits, "Ostats_plot_object")))
+  }
+)
+
+test_that(
+  "Multiple discrete trait plot returns valid output",
+  {
+    expect_true(length(plist2) == 3L & all(sapply(plist2, inherits, "Ostats_plot_object")))
+  }
+)
+
+test_that(
+  "Multiple continuous circular trait plot with means panels returns valid output",
+  {
+    expect_true(length(plist3) == 3L & all(sapply(plist3, inherits, "Ostats_plot_object")))
+  }
+)
+
+test_that(
+  "Multiple discrete circular trait plot returns valid output",
+  {
+    expect_true(length(plist4) == 3L & all(sapply(plist4, inherits, "Ostats_plot_object")))
+  }
+)

--- a/tests/testthat/test-Ostats_plot.R
+++ b/tests/testthat/test-Ostats_plot.R
@@ -7,6 +7,9 @@ context("Ostats_plot")
 # If multiple traits are plotted, test length(p) == number of traits
 # and all(sapply(p, inherits, "Ostats_plot_object"))
 
+# suppressWarnings() must be used to suppress a ggplot2 warning
+# that arises when setting limits on geom_histogram().
+
 # Set up data for test, making multiple trait columns from the ant data.
 data(ant_data)
 
@@ -16,12 +19,6 @@ ant_data$time3 <- ant_data$time %% 6
 sp <- ant_data$species
 plots <- ant_data$chamber
 traits <- ant_data[, c('time', 'time2', 'time3')]
-
-# Multiple traits:
-plist1 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, means = TRUE)
-plist2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE)
-plist3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)
-plist4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE, circular = TRUE)
 
 # Tests 1-4: single trait plots
 test_that(
@@ -60,6 +57,7 @@ test_that(
 test_that(
   "Multiple continuous trait plot with means panels returns valid output",
   {
+    plist1 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, means = TRUE)
     expect_true(length(plist1) == 3L & all(sapply(plist1, inherits, "Ostats_plot_object")))
   }
 )
@@ -67,6 +65,7 @@ test_that(
 test_that(
   "Multiple discrete trait plot returns valid output",
   {
+    plist2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE)
     expect_true(length(plist2) == 3L & all(sapply(plist2, inherits, "Ostats_plot_object")))
   }
 )
@@ -74,6 +73,7 @@ test_that(
 test_that(
   "Multiple continuous circular trait plot with means panels returns valid output",
   {
+    plist3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)
     expect_true(length(plist3) == 3L & all(sapply(plist3, inherits, "Ostats_plot_object")))
   }
 )
@@ -81,6 +81,7 @@ test_that(
 test_that(
   "Multiple discrete circular trait plot returns valid output",
   {
+    plist4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE, circular = TRUE)
     expect_true(length(plist4) == 3L & all(sapply(plist4, inherits, "Ostats_plot_object")))
   }
 )

--- a/tests/testthat/test-Ostats_plot.R
+++ b/tests/testthat/test-Ostats_plot.R
@@ -1,0 +1,6 @@
+library(Ostats)
+context("Ostats_plot")
+
+# Unit tests for Ostats_plot() to be put here.
+# Tests should verify that an object of class Ostats_plot_object is created successfully
+# for continuous data, discrete data, and circular data.

--- a/tests/testthat/test-Ostats_plot.R
+++ b/tests/testthat/test-Ostats_plot.R
@@ -32,7 +32,7 @@ test_that(
 test_that(
   "Single discrete trait plot returns valid output",
   {
-    p2 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = TRUE, normalize = FALSE)
+    suppressWarnings(p2 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = TRUE, normalize = FALSE))
     expect_true(inherits(p2, "Ostats_plot_object"))
   }
 )
@@ -40,7 +40,7 @@ test_that(
 test_that(
   "Single continuous circular trait plot with means panels returns valid output",
   {
-    p3 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)
+    suppressWarnings(p3 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE))
     expect_true(inherits(p3, "Ostats_plot_object"))
   }
 )
@@ -48,7 +48,7 @@ test_that(
 test_that(
   "Single discrete circular trait plot returns valid output",
   {
-    p4 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = TRUE, normalize = FALSE, circular = TRUE)
+    suppressWarnings(p4 <- Ostats_plot(plots = plots, sp = sp, traits = traits[, 1, drop = FALSE], discrete = TRUE, normalize = FALSE, circular = TRUE))
     expect_true(inherits(p4, "Ostats_plot_object"))
   }
 )
@@ -65,7 +65,7 @@ test_that(
 test_that(
   "Multiple discrete trait plot returns valid output",
   {
-    plist2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE)
+    suppressWarnings(plist2 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE))
     expect_true(length(plist2) == 3L & all(sapply(plist2, inherits, "Ostats_plot_object")))
   }
 )
@@ -73,7 +73,7 @@ test_that(
 test_that(
   "Multiple continuous circular trait plot with means panels returns valid output",
   {
-    plist3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE)
+    suppressWarnings(plist3 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = FALSE, normalize = FALSE, circular = TRUE, means = TRUE))
     expect_true(length(plist3) == 3L & all(sapply(plist3, inherits, "Ostats_plot_object")))
   }
 )
@@ -81,7 +81,7 @@ test_that(
 test_that(
   "Multiple discrete circular trait plot returns valid output",
   {
-    plist4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE, circular = TRUE)
+    suppressWarnings(plist4 <- Ostats_plot(plots = plots, sp = sp, traits = traits, discrete = TRUE, normalize = FALSE, circular = TRUE))
     expect_true(length(plist4) == 3L & all(sapply(plist4, inherits, "Ostats_plot_object")))
   }
 )

--- a/tests/testthat/test-community_overlap.R
+++ b/tests/testthat/test-community_overlap.R
@@ -14,23 +14,22 @@ trait_harv <- as.matrix(dat[dat$siteID %in% 'HARV', 'log_weight', drop = FALSE])
 spp_harv <- factor(dat$taxonID[dat$siteID %in% 'HARV'])
 
 # Test 1. Verify correct output format if raw = FALSE
-result1 <- community_overlap(traits = trait_harv, sp = spp_harv)
-expected1 <- 0.8946
-
 test_that (
   "community_overlap() returns expected output when raw = FALSE",
   {
+    result1 <- community_overlap(traits = trait_harv, sp = spp_harv)
+    expected1 <- 0.8946
     expect_equivalent(result1, expected1, tolerance = 0.001)
   }
 )
 
 # Test 2. Verify correct output format if raw = TRUE
-result2 <- community_overlap(traits = trait_harv, sp = spp_harv, raw = TRUE)
-
 test_that (
   "community_overlap() returns expected output when raw = TRUE",
   {
-    expect_equivalent(result2[['value']], expected1, tolerance = 0.001)
+    result2 <- community_overlap(traits = trait_harv, sp = spp_harv, raw = TRUE)
+    expected2 <- 0.8946
+    expect_equivalent(result2[['value']], expected2, tolerance = 0.001)
     expect_s3_class(result2[['raw']], 'data.frame')
     expect_length(result2[['raw']][['overlap']], 10)
   }


### PR DESCRIPTION
Enables plotting of

- discrete traits
- circular traits
- discrete circular traits
- normalized (all density plots have area 1) and non-normalized (density plot area is proportional to taxon abundance) overlap

Closes #50 and #51 !